### PR TITLE
Fix problem with gradients accumulating

### DIFF
--- a/ttach/wrappers.py
+++ b/ttach/wrappers.py
@@ -77,14 +77,15 @@ class ClassificationTTAWrapper(nn.Module):
         self, image: torch.Tensor, *args
     ) -> Union[torch.Tensor, Mapping[str, torch.Tensor]]:
         merger = Merger(type=self.merge_mode, n=len(self.transforms))
-
-        for transformer in self.transforms:
-            augmented_image = transformer.augment_image(image)
-            augmented_output = self.model(augmented_image, *args)
-            if self.output_key is not None:
-                augmented_output = augmented_output[self.output_key]
-            deaugmented_output = transformer.deaugment_label(augmented_output)
-            merger.append(deaugmented_output)
+        
+        with torch.no_grad():
+            for transformer in self.transforms:
+                augmented_image = transformer.augment_image(image)
+                augmented_output = self.model(augmented_image, *args)
+                if self.output_key is not None:
+                    augmented_output = augmented_output[self.output_key]
+                deaugmented_output = transformer.deaugment_label(augmented_output)
+                merger.append(deaugmented_output)
 
         result = merger.result
         if self.output_key is not None:


### PR DESCRIPTION
The problem arises because a gradient accumulates in the layers with each new transformation.
Let's imagine, that original model works well with batch_size 128 (for example) and GPU was fully loaded, then wrapped model with several transform will crash for similar batch_size = 128, it will work only for batch size ~= 40. 
To fix this problem I added `torch._no_grad()`.

PS. If you now about this problem and assume that this code must be added in outer function, then you have to change your example snippet from readme because it doesn't include `no_grad()`. But in my opinion, it will be better left this code here, inside the forward. 