### PR TITLE
fix a typo in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ tta_model = tta.SegmentationTTAWrapper(model, tta.aliases.d4_transform(), merge_
 ```
 #####  Classification model wrapping:
 ```python
-tta_model = tta.ClassificationTTAWrapper(model, tta.aliases.five_crops_transform())
+tta_model = tta.ClassificationTTAWrapper(model, tta.aliases.five_crop_transform())
 ```
 
 ## Advanced Examples


### PR DESCRIPTION
five_crops_transform should be five_crop_transform.
otherwise anAttributeError will be raised.

tta_model = tta.ClassificationTTAWrapper(model, tta.aliases.five_crops_transform())
AttributeError: module 'ttach.aliases' has no attribute 'five_crops_transform'